### PR TITLE
Update setup.py

### DIFF
--- a/tensorflow_binding/setup.py
+++ b/tensorflow_binding/setup.py
@@ -8,6 +8,7 @@ import re
 import setuptools
 import sys
 import unittest
+import warnings
 from setuptools.command.build_ext import build_ext as orig_build_ext
 from distutils.version import LooseVersion
 


### PR DESCRIPTION
solved the problem of "NameError: name 'warnings' is not defined"