### PR TITLE
Fix illegal memory access of compute_grad_kernel

### DIFF
--- a/include/detail/gpu_rnnt_kernel.h
+++ b/include/detail/gpu_rnnt_kernel.h
@@ -168,7 +168,7 @@ __global__ void compute_grad_kernel(Tp* grads, const Tp* const acts, const Tp* c
             if (idx == blank_ && t < T-1) {
                 grad -= exp(alphas[col] + logpk - logll[mb] + betas[col + maxU]);
             }
-            if (idx == labels[u] && u < U-1) {
+            if (u < U-1 && idx == labels[u]) {
                 grad -= exp(alphas[col] + logpk - logll[mb] + betas[col+1]);
             }
             grads[col * alphabet_size + idx] = grad;


### PR DESCRIPTION
If `mb == minibatch_size - 1 && u == U-1`,
`labels[u]` is out-of-bounds memory access.