### PR TITLE
Update pytorch_binding/setup.py

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -35,7 +35,7 @@ if not os.path.exists(os.path.join(warp_rnnt_path, "libwarprnnt" + lib_ext)):
            "Build warp-rnnt and set WARP_RNNT_PATH to the location of"
            " libwarprnnt.so (default is '../build')").format(warp_rnnt_path))
     sys.exit(1)
-include_dirs = [os.path.realpath('../include')]
+include_dirs = [os.path.realpath('../include'), '/usr/local/cuda/include/']
 
 setup(
     name='warprnnt_pytorch',


### PR DESCRIPTION
When I ran 'python setup.py install' command, an error of 'CUDAStream.h:6:10: fatal error: cuda_runtime_api.h: No such file or directory' occurred.

I fixed it by modifying setup.py:
`include_dirs = [os.path.realpath('../include')]`
to
`include_dirs = [os.path.realpath('../include'), '/path/to/cuda/include/']`